### PR TITLE
パッケージ名の分割を修正

### DIFF
--- a/gitkraken.entry
+++ b/gitkraken.entry
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #-- 表示名 --#
-name="Git Kraken"
+name="Git-Kraken"
 
 #-- パッケージ名 --#
 package_name="gitkraken"


### PR DESCRIPTION
パッケージ名に半角スペースが入っていると半角スペースの部分で分割され、資料のようになってしまうので修正します。

資料
| 選択 | パッケージ | インストール済 | 説明                                    | 
| ---- | ---------- | -------------- | --------------------------------------- | 
| □   | Firefox    | いいえ         | Mozilla製の高速で動作するウェブブラウザ | 
| □   | Git        | Kraken         | いいえ                                  | 
| □   | False      | google-chrome  | いいえ                                  | 
| □   | False      | pinta          | いいえ                                  | 
| □   | False      | Skype          | いいえ                                  | 
| □   | False      | Slack          | いいえ                                  | 
| □   |            |                |                                         |